### PR TITLE
Dif expr

### DIFF
--- a/.github/workflows/rustematica-root-dev-ubuntu.yml
+++ b/.github/workflows/rustematica-root-dev-ubuntu.yml
@@ -2,21 +2,20 @@ name: rustematica-root-dev-ubuntu
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master", "dev"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v3
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose

--- a/.github/workflows/rustematica-root-release-ubuntu.yml
+++ b/.github/workflows/rustematica-root-release-ubuntu.yml
@@ -2,21 +2,20 @@ name: rustematica-root-release-ubuntu
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master", "dev"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose --release
-    - name: Run tests
-      run: cargo test --verbose --release
+      - uses: actions/checkout@v3
+      - name: Build
+        run: cargo build --verbose --release
+      - name: Run tests
+        run: cargo test --verbose --release

--- a/.github/workflows/rustemetica-root-dev-macos.yml
+++ b/.github/workflows/rustemetica-root-dev-macos.yml
@@ -2,21 +2,20 @@ name: rustemetica-root-dev-macos
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master", "dev"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v3
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose

--- a/.github/workflows/rustemetica-root-dev-windows.yml
+++ b/.github/workflows/rustemetica-root-dev-windows.yml
@@ -2,21 +2,20 @@ name: rustemetica-root-dev-windows
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master", "dev"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v3
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose

--- a/.github/workflows/rustemetica-root-release-macos.yml
+++ b/.github/workflows/rustemetica-root-release-macos.yml
@@ -2,21 +2,20 @@ name: rustemetica-root-release-macos
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master", "dev"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose --release
-    - name: Run tests
-      run: cargo test --verbose --release
+      - uses: actions/checkout@v3
+      - name: Build
+        run: cargo build --verbose --release
+      - name: Run tests
+        run: cargo test --verbose --release

--- a/.github/workflows/rustemetica-root-release-windows.yml
+++ b/.github/workflows/rustemetica-root-release-windows.yml
@@ -2,21 +2,20 @@ name: rustemetica-root-release-windows
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master", "dev"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose --release
-    - name: Run tests
-      run: cargo test --verbose --release
+      - uses: actions/checkout@v3
+      - name: Build
+        run: cargo build --verbose --release
+      - name: Run tests
+        run: cargo test --verbose --release

--- a/examples/poly/src/main.rs
+++ b/examples/poly/src/main.rs
@@ -1,4 +1,4 @@
-use rustemetica::expr::{Dif, Poly, Vars};
+use rustemetica::expr::{AtomicExpr, Dif, Poly, Vars};
 
 fn main() {
     let poly1 = Poly::from(5f64, Vars::x, 3f64);
@@ -11,13 +11,15 @@ fn main() {
         poly2.to_string(),
         poly3.to_string()
     );
+    print!("d/dx {} = ", origin);
 
-    let diff = format!(
-        "{} + {} + {}",
-        poly1.differentiate().to_string(),
-        poly2.differentiate().to_string(),
-        poly3.differentiate().to_string()
-    );
-
-    println!("d/dx {} = {}", origin, diff)
+    if let AtomicExpr::Poly(poly) = poly1.differentiate() {
+        print!("{} ", poly.to_string());
+    }
+    if let AtomicExpr::Poly(poly) = poly2.differentiate() {
+        print!("{} ", poly.to_string());
+    }
+    if let AtomicExpr::Constant(con) = poly3.differentiate() {
+        println!("{}", con);
+    }
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -197,7 +197,7 @@ impl Const {
         Self { value }
     }
 
-    pub fn into(&self) -> f64 {
+    pub fn to_f64(&self) -> f64 {
         self.value
     }
 }
@@ -280,6 +280,15 @@ mod tests {
             assert_eq!(con.value, 0f64);
         } else {
             panic!("Differentiated value should be zero");
+        }
+    }
+
+    #[test]
+    pub fn dif_poly_to_const() {
+        if let AtomicExpr::Constant(con) = Poly::from(3., Vars::x, 1.).differentiate() {
+            assert_eq!(con.to_f64(), 3.);
+        } else {
+            panic!("Differentiated value should be Constant");
         }
     }
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -180,7 +180,11 @@ impl Dif for Poly {
 
 impl Display for Poly {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}{}^{}", self.coe, self.var.to_str(), self.ex)
+        if self.ex == 1. {
+            write!(f, "{}{}", self.coe, self.var.to_str())
+        } else {
+            write!(f, "{}{}^{}", self.coe, self.var.to_str(), self.ex)
+        }
     }
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -196,6 +196,10 @@ impl Const {
     pub fn from(value: f64) -> Self {
         Self { value }
     }
+
+    pub fn into(&self) -> f64 {
+        self.value
+    }
 }
 
 impl Display for Const {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -125,7 +125,6 @@ pub enum AtomicExpr {
     Constant(Const),
     Exponent(),
     Log(),
-    None,
 }
 
 /// Dif trait means a struct which implements Dif


### PR DESCRIPTION
Fixes #3 
Fixes #11 
Fixes #13 

# Updates
1. struct `Expr` is renamed to enum `AtomicExpr`
2. `None` is removed from `AtomicExpr`
3. New function `to_f64()` in Constant
4. $\frac{d}{dx}x$ will be rendered $x$, no longer $x^1$
5. Test will be executed on dev branch PR